### PR TITLE
Changing cdp-refresh to create all tables as databricks managed

### DIFF
--- a/cdp-conversion-library.py
+++ b/cdp-conversion-library.py
@@ -1,4 +1,8 @@
 # Databricks notebook source
+dbutils.widgets.text('parquet_path', 's3://acid-cdp-staging', 'Base location of parquet files')
+
+input_path = dbutils.widgets.get('parquet_path')
+PARQUET_PATH = input_path[0:-1] if input_path.endswith('/') else input_path
 
 
 # COMMAND ----------
@@ -9,6 +13,7 @@ def is_table_databricks_managed(org_id, entity_table):
       print(f"Table {org_id}.{entity_table} is databricks managed")
       return True
     print(f"Table {org_id}.{entity_table} is NOT databricks managed")
+    return False
   except AnalysisException as Ex:
     print(f"Table {org_id}.{entity_table} not found, creating table now")
     spark.sql(f"CREATE DATABASE IF NOT EXISTS {org_id}")
@@ -35,7 +40,7 @@ def get_all_files(org_id, entity_table):
   org_id = org_id.split("_")[-1]
   file_info_list = dbutils.fs.ls(f"{parquet_path}/{org_id}/{entity_table_id}")
   for file_info in file_info_list:
-    file_path_list += [file_info[0].replace("dbfs:/mnt/cdp/", "s3://usermind-preprod-cdp/")]
+    file_path_list += [file_info[0]]
   print(f"Retrieved files for {org_id}.{entity_table}: {file_path_list}")
   return file_path_list
 
@@ -76,7 +81,3 @@ def delete_files(file_list):
   for file in file_list:
     print(f"Removing file {file}")
     dbutils.fs.rm(file)
-
-# COMMAND ----------
-
-

--- a/cdp-conversion-library.py
+++ b/cdp-conversion-library.py
@@ -1,0 +1,90 @@
+# Databricks notebook source
+
+
+# COMMAND ----------
+
+def is_table_databricks_managed(org_id, entity_table):
+  try:
+    if spark.sql(f"DESCRIBE TABLE EXTENDED {org_id}.{entity_table}").where("col_name = 'Type' AND data_type = 'MANAGED'").count() > 0:
+      print(f"Table {org_id}.{entity_table} is databricks managed")
+      return True
+    print(f"Table {org_id}.{entity_table} is NOT databricks managed")
+  except AnalysisException as Ex:
+    print(f"Table {org_id}.{entity_table} not found, creating table now")
+    spark.sql(f"CREATE DATABASE IF NOT EXISTS {org_id}")
+    print(f"Successfully database table {org_id}")
+    file_list = get_all_files(org_id, entity_table)
+    load_data(org_id, entity_table, file_list)
+    return True
+  
+# We are no longer using the parquet location for the table so we want the query up to the USING keyword and then add um_creation_date and um_processed_timestamp columns  
+def format_create_table_query(create_table_query):
+  unclosed_query = create_table_query.split(")  USING")[0]
+  unclosed_query += ", `um_processed_date` DATE"
+  closed_query = unclosed_query + ")"
+  closed_query += "PARTITIONED BY (um_processed_date)"
+  return closed_query
+
+# Creates backup of existing table, loads all existing data into table with suffix _dbtemp, drops existing table, and then renames db_temp table to replace table
+def replace_table_with_databricks_managed_table(org_id, entity_table):
+  print(f"Starting replacement process for {org_id}.{entity_table}")
+  spark.sql(f"CREATE TABLE {org_id}.{entity_table}_backup AS SELECT * FROM {org_id}.{entity_table}")
+  print(f"Finished creating {org_id}.{entity_table}_backup")
+  file_list = get_all_files(org_id, entity_table)
+  load_data(org_id, entity_table + "_dbtemp", file_list)
+  drop_table(org_id, entity_table)
+  rename_dbtemp_table(org_id, entity_table)
+
+#Gets all parquet files for a given org_id.entity_table
+def get_all_files(org_id, entity_table):
+  print(f"Retrieving all files for {org_id}.{entity_table}")
+  file_path_list = []
+  entity_table_id = entity_table.split("_")[-1]
+  org_id = org_id.split("_")[-1]
+  file_info_list = dbutils.fs.ls(f"{parquet_path}/{org_id}/{entity_table_id}")
+  for file_info in file_info_list:
+    file_path_list += [file_info[0].replace("dbfs:/mnt/cdp/", "s3://usermind-preprod-cdp/")]
+  print(f"Retrieved files for {org_id}.{entity_table}: {file_path_list}")
+  return file_path_list
+
+def read_files(file_list):
+  if len(file_list) > 0:
+    return spark.read.parquet(*file_list)
+  print("Newer file list was empty, returning None")
+  return None
+
+# Reads in all data from file_list and adds um_processed_date before appending the data to the org_id.entity_table
+def load_data(org_id, entity_table, file_list):
+  print(f"Loading all data to {org_id}.{entity_table}")
+  existing_data_df = read_files(file_list)
+  if existing_data_df is None:
+    print("No files to read, skipping to next entityTable")
+    return
+  print("Successfully read all data")
+  existing_data_df = existing_data_df.withColumn("um_processed_date", F.to_date(F.col("um_creation_date_utc"),"MM-dd-yyyy"))
+  print("Successfully added um_processed_date column")
+  append_data_to_table(existing_data_df, org_id, entity_table)
+
+  print(f"Successfully appended data to {org_id}.{entity_table}")
+
+def append_data_to_table(newer_data, org_id, entity_table):
+  if newer_data:
+    newer_data.write.partitionBy("um_processed_date").mode("append").saveAsTable(f"{org_id}.{entity_table}")
+  else:
+    print("Dataframe passed to append_newer_file_dataframe with {org_id}.{entity_table} was None, not appending data")
+
+def drop_table(org_id, entity_table):
+    spark.sql(f"DROP TABLE {org_id}.{entity_table}")
+
+def rename_dbtemp_table(org_id, entity_table):
+  spark.sql(f"ALTER TABLE {org_id}.{entity_table}_dbtemp RENAME TO {org_id}.{entity_table}")
+  
+    
+def delete_files(file_list):
+  for file in file_list:
+    print(f"Removing file {file}")
+    dbutils.fs.rm(file)
+
+# COMMAND ----------
+
+

--- a/cdp-conversion-library.py
+++ b/cdp-conversion-library.py
@@ -16,14 +16,6 @@ def is_table_databricks_managed(org_id, entity_table):
     file_list = get_all_files(org_id, entity_table)
     load_data(org_id, entity_table, file_list)
     return True
-  
-# We are no longer using the parquet location for the table so we want the query up to the USING keyword and then add um_creation_date and um_processed_timestamp columns  
-def format_create_table_query(create_table_query):
-  unclosed_query = create_table_query.split(")  USING")[0]
-  unclosed_query += ", `um_processed_date` DATE"
-  closed_query = unclosed_query + ")"
-  closed_query += "PARTITIONED BY (um_processed_date)"
-  return closed_query
 
 # Creates backup of existing table, loads all existing data into table with suffix _dbtemp, drops existing table, and then renames db_temp table to replace table
 def replace_table_with_databricks_managed_table(org_id, entity_table):

--- a/cdp-refresh.py
+++ b/cdp-refresh.py
@@ -18,6 +18,10 @@ from py4j.protocol import Py4JJavaError
 
 # COMMAND ----------
 
+# MAGIC %run /Repos/CDP/UberStream/cdp-conversion-library
+
+# COMMAND ----------
+
 #All postgres access functions here.
 
 thylacine_aurora_username = dbutils.secrets.get(scope = "thylacine-aurora", key = "username")
@@ -32,12 +36,12 @@ current_env = dbutils.secrets.get(scope = "databricks-workspaces", key = "curren
 input_path = dbutils.widgets.get('parquet_path')
 parquet_path = input_path[0:-1] if input_path.endswith('/') else input_path
 
-def delete_from_update_table(max_id):
+def delete_from_update_table(id):
   conn = None
   try:
     conn = psycopg2.connect(host=jdbc_hostname,database=jdbc_database, user=thylacine_aurora_username, password=thylacine_aurora_password)
     cur = conn.cursor()
-    delete_sql = "DELETE FROM umcnc.table_updates_parquet WHERE id <= " + str(max_id)
+    delete_sql = "DELETE FROM umcnc.table_updates_parquet WHERE id = " + str(id)
     print(delete_sql)
     cur.execute(delete_sql)
     cur.close()
@@ -95,79 +99,7 @@ def fix_spark_sql_missing_columns(org_id, entity_table):
     print(f'table {org_id}.{entity_table} is up to date')
 
 # Checks if data type of table is MANAGED 
-def is_table_databricks_managed(org_id, entity_table, create_table_query):
-  try:
-    if spark.sql(f"DESCRIBE TABLE EXTENDED {org_id}.{entity_table}").where("col_name = 'Type' AND data_type = 'MANAGED'").count() > 0:
-      print(f"Table {org_id}.{entity_table} is databricks managed")
-      return True
-    print(f"Table {org_id}.{entity_table} is NOT databricks managed")
-  except AnalysisException as Ex:
-    print(f"Table {org_id}.{entity_table} not found, creating table now")
-    spark.sql(f"CREATE DATABASE IF NOT EXISTS {org_id}")
-    spark.sql(create_table_query)
-    print(f"Successfully created table {org_id}.{entity_table}")
-    return True
-  
-# We are no longer using the parquet location for the table so we want the query up to the USING keyword and then add um_creation_date and um_processed_timestamp columns  
-def format_create_table_query(create_table_query):
-  unclosed_query = create_table_query.split(")  USING")[0]
-  unclosed_query += ", `um_processed_date` DATE"
-  closed_query = unclosed_query + ")"
-  closed_query += "PARTITIONED BY (um_processed_date)"
-  return closed_query
 
-# Creates backup of existing table, drops table, and then creates a new table partitioned by um_processed_date
-def replace_table_with_databricks_managed_table(org_id, entity_table, create_table_query):
-  print(f"Starting replacement process for {org_id}.{entity_table}")
-  spark.sql(f"CREATE TABLE {org_id}.{entity_table}_backup AS SELECT * FROM {org_id}.{entity_table}")
-  print(f"Finished creating {org_id}.{entity_table}_backup")
-  #Overwrite original table with processingDate and partitioned by processingDate
-  print(f"Dropping original non-databricks managed table {org_id}.{entity_table}")
-  spark.sql(f"DROP TABLE {org_id}.{entity_table}")
-  print(f"Recreating databricks managed table from {org_id}.{entity_table}")
-  spark.sql(f"{create_table_query}")  
-
-#Gets all parquet files for a given org_id.entity_table
-def get_all_files(org_id, entity_table):
-  print(f"Retrieving all files for {org_id}.{entity_table}")
-  file_path_list = []
-  entity_table_id = entity_table.split("_")[-1]
-  org_id = org_id.split("_")[-1]
-  file_info_list = dbutils.fs.ls(f"{parquet_path}/{org_id}/{entity_table_id}")
-  for file_info in file_info_list:
-    file_path_list += [file_info[0].replace("dbfs:/mnt/cdp/", "s3://usermind-preprod-cdp/")]
-  print(f"Retrieved files for {org_id}.{entity_table}: {file_path_list}")
-  return file_path_list
-
-def read_files(file_list):
-  if len(file_list) > 0:
-    return spark.read.parquet(*file_list)
-  print("Newer file list was empty, returning None")
-  return None
-
-# Reads in all data from file_list and adds um_processed_date before appending the data to the org_id.entity_table
-def load_data(org_id, entity_table, file_list):
-  existing_data_df = read_files(file_list)
-  if existing_data_df is None:
-    print("No files to read, skipping to next entityTable")
-    return
-  print("Successfully read all data")
-  existing_data_df = existing_data_df.withColumn("um_processed_date", F.to_date(F.col("um_creation_date_utc"),"MM-dd-yyyy"))
-  print("Successfully added um_processed_date column")
-  existing_data_df.show()
-  append_data_to_table(existing_data_df, org_id, entity_table)
-  print(f"Successfully appended data to {org_id}.{entity_table}")
-
-def append_data_to_table(newer_data, org_id, entity_table):
-  if newer_data:
-    newer_data.write.mode("append").saveAsTable(f"{org_id}.{entity_table}")
-  else:
-    print("Dataframe passed to append_newer_file_dataframe with {org_id}.{entity_table} was None, not appending data")
-
-def delete_files(file_list):
-  for file in file_list:
-    print(f"Removing file {file}")
-    dbutils.fs.rm(file)
 
 # COMMAND ----------
 
@@ -177,17 +109,15 @@ def delete_files(file_list):
 data = select_from_update_table()
 
 # Store max id so that we can delete records after refresh
-max_id = data.agg({"id": "max"}).collect()[0]["max(id)"]
-print("Max id: " + str(max_id))
-
 # get data count for timings
 data_count = data.count();
 print("Entities to update: " + str(data_count))
 
 if data_count > 0:
   # refresh tables
-  data.show(20, False)
   pending_refreshes = data.rdd.collect()
+  print(pending_refreshes)
+  raise Ex()
   for table_row in pending_refreshes:
     try:
         print(table_row)
@@ -195,15 +125,19 @@ if data_count > 0:
         org_id = table_dict["schema_name"]
         entity_table = table_dict["table_name"]
         file_list = get_all_files(org_id, entity_table)
-        create_table_query = format_create_table_query(table_dict["create_table_query"])
         if not is_table_databricks_managed(org_id, entity_table, create_table_query):
-          replace_table_with_databricks_managed_table(org_id, entity_table, create_table_query)
+          replace_table_with_databricks_managed_table(org_id, entity_table)
         elif len(file_list) > 0:
           fix_spark_sql_missing_columns(org_id, entity_table)
-        print(f"Found the following files to append to {org_id}.{entity_table}: {file_list}")
-        load_data(org_id, entity_table, file_list)
-        delete_files(file_list)
+          print(f"Found the following files to append to {org_id}.{entity_table}: {file_list}")
+          load_data(org_id, entity_table, file_list)
+        #delete_files(file_list)
+        #delete_from_update_table(table_dict["id"])
     except Exception as ex:
         print(f"Unable to process {org_id}.{entity_table} due to exception: {ex}")
         raise ex
-  delete_from_update_table(max_id)
+  
+
+# COMMAND ----------
+
+

--- a/cdp-refresh.py
+++ b/cdp-refresh.py
@@ -1,8 +1,6 @@
 # Databricks notebook source
 sqlContext.sql('set spark.sql.caseSensitive=true')
 
-dbutils.widgets.text('parquet_path', 's3://acid-cdp-staging', 'Base location of parquet files')
-
 # COMMAND ----------
 
 from pyspark.sql import functions as F

--- a/cdp-refresh.py
+++ b/cdp-refresh.py
@@ -73,7 +73,7 @@ def get_newest_file(org_id, entity_table):
   org_id = org_id.split("_")[-1]
   entity_table_id = entity_table.split("_")[-1]
   file_info_list = dbutils.fs.ls(f"{parquet_path}/{org_id}/{entity_table_id}")
-  most_recent_time = 1658188800011 #Epoc start
+  most_recent_time = 0 #Epoc start
   most_recent_file = ""
   for file_info in file_info_list:
     if file_info[3] > most_recent_time:

--- a/cdp-table-conversion.py
+++ b/cdp-table-conversion.py
@@ -28,16 +28,15 @@ entity_table = ""
 # Iterates through all schemas that start with org_
 for row in spark.sql("SHOW SCHEMAS LIKE 'org_*'").collect():
     # Shows tables in the schema not starting with usermind that ends in at least 3 numbers
-    print(row)
     for database_row in spark.sql(f"SHOW TABLES FROM {row[0]} LIKE '^((?!usermind).)*([0-9]){{3,20}}$'").collect():
         try:
           org_id, entity_table = database_row[0], database_row[1]
+          print(f"Processing {org_id}.{entity_table}")
           if is_table_databricks_managed(org_id, entity_table):
             print("Table {org_id}.{entity_table} is already databricks managed. Skipping processing.")
             continue
           print(f"Processing org {org_id} and table {entity_table}")
           replace_table_with_databricks_managed_table(org_id, entity_table, file_list)
-          raise ex()
           delete_files(file_list)
         except Exception as ex:
           print(f"Encountered exception while processing {org_id}.{enttity_table}: {ex}", org_id, entity_table, ex)

--- a/cdp-table-conversion.py
+++ b/cdp-table-conversion.py
@@ -7,14 +7,6 @@ from pyspark.sql import functions as F
 
 # COMMAND ----------
 
-dbutils.widgets.text('parquet_path', 's3://acid-cdp-staging', 'Base location of parquet files')
-
-input_path = dbutils.widgets.get('parquet_path')""
-parquet_path = input_path[0:-1] if input_path.endswith('/') else input_path
-
-
-# COMMAND ----------
-
 # MAGIC %sql
 # MAGIC CREATE DATABASE IF NOT EXISTS usermind_reporting 
 
@@ -48,24 +40,6 @@ for row in spark.sql("SHOW SCHEMAS LIKE 'org_*'").collect():
           raise ex()
           delete_files(file_list)
         except Exception as ex:
-          print("something", org_id, entity_table, ex)
-          raise ex
-          write_failure(org_id, entity_table, "fake ex")
+          print(f"Encountered exception while processing {org_id}.{enttity_table}: {ex}", org_id, entity_table, ex)
+          write_failure(org_id, entity_table, str(ex))
           
-
-# COMMAND ----------
-
-spark.sql("SHOW TABLES FROM org_1089824 LIKE '^((?!usermind).)*([0-9])+$'").show()
-
-# COMMAND ----------
-
-rename_dbtemp_table("org_1012768", "csv_importer_test1_1045748")
-
-# COMMAND ----------
-
-dbutils.fs.ls("/mnt/")
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC ALTER TABLE 

--- a/cdp-table-conversion.py
+++ b/cdp-table-conversion.py
@@ -1,0 +1,71 @@
+# Databricks notebook source
+from pyspark.sql import functions as F
+
+# COMMAND ----------
+
+# MAGIC %run /Repos/CDP/UberStream/cdp-conversion-library
+
+# COMMAND ----------
+
+dbutils.widgets.text('parquet_path', 's3://acid-cdp-staging', 'Base location of parquet files')
+
+input_path = dbutils.widgets.get('parquet_path')""
+parquet_path = input_path[0:-1] if input_path.endswith('/') else input_path
+
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC CREATE DATABASE IF NOT EXISTS usermind_reporting 
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC CREATE TABLE IF NOT EXISTS usermind_reporting.failed_db_conversions (org_id STRING, entity_table STRING, exceptionMesage STRING)
+
+# COMMAND ----------
+
+def write_failure(org_id, entity_table, ex):
+  spark.sql(f"INSERT INTO usermind_reporting.failed_db_conversions VALUES('{org_id}', '{entity_table}', '{str(ex)}')")
+
+# COMMAND ----------
+
+
+org_id = ""
+entity_table = ""
+# Iterates through all schemas that start with org_
+for row in spark.sql("SHOW SCHEMAS LIKE 'org_*'").collect():
+    # Shows tables in the schema not starting with usermind that ends in at least 3 numbers
+    print(row)
+    for database_row in spark.sql(f"SHOW TABLES FROM {row[0]} LIKE '^((?!usermind).)*([0-9]){{3,20}}$'").collect():
+        try:
+          org_id, entity_table = database_row[0], database_row[1]
+          if is_table_databricks_managed(org_id, entity_table):
+            print("Table {org_id}.{entity_table} is already databricks managed. Skipping processing.")
+            continue
+          print(f"Processing org {org_id} and table {entity_table}")
+          replace_table_with_databricks_managed_table(org_id, entity_table, file_list)
+          raise ex()
+          delete_files(file_list)
+        except Exception as ex:
+          print("something", org_id, entity_table, ex)
+          raise ex
+          write_failure(org_id, entity_table, "fake ex")
+          
+
+# COMMAND ----------
+
+spark.sql("SHOW TABLES FROM org_1089824 LIKE '^((?!usermind).)*([0-9])+$'").show()
+
+# COMMAND ----------
+
+rename_dbtemp_table("org_1012768", "csv_importer_test1_1045748")
+
+# COMMAND ----------
+
+dbutils.fs.ls("/mnt/")
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC ALTER TABLE 


### PR DESCRIPTION
This PR is related to this ticket: https://qualtrics.atlassian.net/browse/UM-625?atlOrigin=eyJpIjoiYzkxNDk1MGI4MmMzNDk1Y2FlZmQ4NGRmMDU3ZWQ5NTkiLCJwIjoiaiJ9.

We want to repartition all entity tables to be partitioned by date. However, because the tables are backed by parquet files in our s3 bucket we are unable to change the partition scheme. To get around this, we are changing the cdp-refresh job to create all new entity tables and databricks managed tables and drop all existing entity tables and recreate them as databricks managed tables.