### PR TITLE
Removed blocks creating tables that are never used and removing hard-…

### DIFF
--- a/Traveler Stream Library.scala
+++ b/Traveler Stream Library.scala
@@ -108,10 +108,6 @@ def startTravelerStream(dfStream : DataFrame) : StreamingQuery = {
       //format stream to just contain traveleevent data
       val dfFormatted = formatTravelerStream(df)
       dfFormatted.createOrReplaceTempView("travelerUpdates")
-
-      //log current batch
-      df.sparkSession.sql(s"""DROP TABLE IF EXISTS $logDatabase.travelerUpdates""")
-      df.sparkSession.sql(s"""CREATE TABLE $logDatabase.travelerUpdates AS SELECT * FROM travelerUpdates""")
       
       //branch by org
       df.sparkSession.sql(s"""SELECT DISTINCT orgId FROM travelerUpdates """)
@@ -138,10 +134,6 @@ def startTravelerStream(dfStream : DataFrame) : StreamingQuery = {
                     WHERE orgId = $orgId AND namespace = '$namespace'
                     """)
                   dfUpdates.createOrReplaceTempView("travelerUpdatesByOrgAndNamespace")       
-
-                  //log current sub batch
-                  df.sparkSession.sql(s"""DROP TABLE IF EXISTS $logDatabase.travelerUpdatesByOrgAndNamespace""")
-                  df.sparkSession.sql(s"""CREATE TABLE $logDatabase.travelerUpdatesByOrgAndNamespace AS SELECT * FROM travelerUpdatesByOrgAndNamespace""")
 
                   val mergeSQL = s"""
                         MERGE INTO org_$orgId.usermind_travelerevent T

--- a/UberStream.scala
+++ b/UberStream.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.streaming._
 
 val inputPath = dbutils.widgets.get("Delta Path")
-val DELTA_PATH = "s3://usermind-preprod-cdp/delta" //if(inputPath.endsWith("/")) inputPath else (inputPath + "/")
+val DELTA_PATH = if(inputPath.endsWith("/")) inputPath else (inputPath + "/")
 
 val kafkaBootstrapServers = dbutils.widgets.get("kafkaBootstrapServers")
 


### PR DESCRIPTION
- The two blocks in the Traveler Stream Library drops and create tables for every batch that aren't actually ever used or read from.  (Note: These tables are not the actual checkpoint table that is created for that stream. It uses streaming_logs.traveler_stream for that)

- Removing hard coded data path